### PR TITLE
Fix marking user as away. #32

### DIFF
--- a/ircb/irc/__init__.py
+++ b/ircb/irc/__init__.py
@@ -84,7 +84,7 @@ class IrcbBot(irc3.IrcBot):
         connection=IrcbIrcConnection
     )
     cmd_regex = re.compile(
-        r'(?P<cmd>[A-Z]+)(?:\s+(?P<args>[^\:]+))?(?:\:(?P<msg>.*))?')
+        r'(?P<cmd>[A-Z]+)(?:\s+(?P<args>[^\:]+))?(?:\s*\:(?P<msg>.*))?')
 
     def __init__(self, *args, **kwargs):
         self.clients = None
@@ -165,7 +165,7 @@ class IrcbBot(irc3.IrcBot):
         elif cmd == 'TOPIC':
             self.topic(args, msg)
         elif cmd == 'AWAY':
-            self.away(args, msg)
+            self.away(msg)
         elif cmd == 'QUIT':
             self.quit(msg)
         elif cmd == 'NICK':


### PR DESCRIPTION
- Fix regex for parsing IRC raw messages, allow for 0 or more whitespaces before 'msg' group
- Fix call to irc3.IrcBot.away()
