### PR TITLE
Load ircb data from file

### DIFF
--- a/ircb/cli/loaddata.py
+++ b/ircb/cli/loaddata.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+import click
+import yaml
+
+from ircb.lib.async import coroutinize
+from ircb.storeclient import UserStore
+from ircb.storeclient import NetworkStore
+
+
+@click.group(name='users')
+def loaddata_cli():
+    "Loads YAML file with config"
+    pass
+
+
+def validate_yaml(f): 
+    "Validates YAML file"
+    return True
+
+
+@click.command(name='loaddata')
+@click.argument('f')
+@coroutinize
+def load_data(f):
+    with open(f, 'r') as f:
+        config = yaml.load(f)
+
+        if validate_yaml(config): 
+
+            for user in config.keys():
+                user_data = config[user]
+                yield from UserStore.create(
+                    dict(
+                        username=user,
+                        email=user_data['email'],
+                        password=user_data['password']
+                    )
+                )
+                networks = user_data['networks']
+                for net in networks.keys():
+                    net_data = networks[net]
+                    network = yield from NetworkStore.create(
+                        dict(
+                            user=user,
+                            name=net,
+                            nickname=net_data["nick"],
+                            hostname=net_data["host"],
+                            port=net_data["port"],
+                            realname=net_data["realname"],
+                            username=net_data["username"],
+                            password=net_data["password"],
+                            usermode=net_data["usermode"],
+                        )
+                    )

--- a/ircb/cli/main.py
+++ b/ircb/cli/main.py
@@ -3,6 +3,7 @@ import click
 from ircb.cli.user import user_cli
 from ircb.cli.network import network_cli
 from ircb.cli.run import run_cli
+from ircb.cli.loaddata import load_data
 
 
 @click.group()
@@ -14,6 +15,7 @@ def cli():
 cli.add_command(user_cli)
 cli.add_command(network_cli)
 cli.add_command(run_cli)
+cli.add_command(load_data)
 
 if __name__ == '__main__':
     cli()

--- a/ircb/cli/network.py
+++ b/ircb/cli/network.py
@@ -6,6 +6,7 @@ from tabulate import tabulate
 from ircb.storeclient import NetworkStore
 from ircb.lib.async import coroutinize
 
+
 @click.group(name='networks')
 def network_cli():
     """Manager networks"""
@@ -29,7 +30,7 @@ def network_cli():
                   ['CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED']))
 @coroutinize
 def create(user, network_name, host, port, nick, realname, username, password,
-           usermode,ssl,ssl_verify):
+           usermode, ssl, ssl_verify):
     """Create a network for a user"""
     network = yield from NetworkStore.create(
         dict(
@@ -76,6 +77,7 @@ def connect(id):
             })
     )
 
+
 @click.command(name='disconnect')
 @click.argument('id')
 @coroutinize
@@ -89,7 +91,7 @@ def disconnect(id):
     )
 
 
-network_cli.add_command(create)
+network_cli.add_command(network_create)
 network_cli.add_command(ls)
 network_cli.add_command(connect)
 network_cli.add_command(disconnect)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==0.10.1
 Flask-SQLAlchemy==2.0
 Flask-User==0.6.4
-SQLAlchemy==1.0.9
+SQLAlchemy==1.0.8
 SQLAlchemy-Utils==0.30.15
 irc3==0.8.3
 alembic==0.8.3


### PR DESCRIPTION
Implemented solution to issue #25 (1st test). Renamed method create to network_create in networks.py from ircb cli
Fix network.py, loaddata.py accordingly to pep8 style
Fix typo (pyyalm to pyyaml) in line 9.
