### PR TITLE
Implement logstore plugin

### DIFF
--- a/ircb/bouncer.py
+++ b/ircb/bouncer.py
@@ -139,6 +139,7 @@ class Bouncer(object):
             })
             config = dict(
                 id=network.id,
+                user_id=user.id,
                 name=network.name,
                 userinfo=network.username,
                 password=network.password,

--- a/ircb/irc/__init__.py
+++ b/ircb/irc/__init__.py
@@ -80,9 +80,12 @@ class IrcbBot(irc3.IrcBot):
             userinfo='{userinfo}',
             time='{now:%c}'
         ),
-        includes=['ircb.irc.plugins.ircb', 'ircb.irc.plugins.autojoins'],
-        connection=IrcbIrcConnection
+        includes=['ircb.irc.plugins.ircb', 'ircb.irc.plugins.autojoins',
+                  'ircb.irc.plugins.logger'],
+        connection=IrcbIrcConnection,
     )
+    defaults['irc3.plugins.logger'] = {
+        'handler': 'ircb.irc.plugins.logger.StoreHandler'}
     cmd_regex = re.compile(
         r'(?P<cmd>[A-Z]+)(?:\s+(?P<args>[^\:]+))?(?:\s*\:(?P<msg>.*))?')
 

--- a/ircb/irc/plugins/logger.py
+++ b/ircb/irc/plugins/logger.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import asyncio
+import datetime
+import irc3
+from irc3.plugins.logger import Logger as Irc3Logger
+from ircb.storeclient import MessageLogStore, ActivityLogStore
+
+
+class StoreHandler(object):
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    def __call__(self, event):
+        if event['event'].lower() == 'privmsg':
+            asyncio.Task(self.handle_message_log(event))
+        elif event['event'].lower() in ('join', 'part', 'quit', 'topic'):
+            asyncio.Task(self.handle_activity_log(event))
+
+    def handle_message_log(self, event):
+        yield from MessageLogStore.create(dict(
+            hostname=event['host'],
+            roomname=event['channel'],
+            message=event['data'],
+            event=event['event'],
+            timestamp=datetime.datetime.utcnow().timestamp(),
+            mask=str(event['mask']),
+            user_id=self.bot.config.get('user_id'),
+            from_nickname=event['mask'].nick
+        ))
+
+    def handle_activity_log(self, event):
+        yield from ActivityLogStore.create(dict(
+            hostname=event['host'],
+            roomname=event['channel'],
+            message=event['data'],
+            event=event['event'],
+            timestamp=datetime.datetime.utcnow().timestamp(),
+            mask=str(event['mask']),
+            user_id=self.bot.config.get('user_id')
+        ))
+        pass
+
+
+@irc3.plugin
+class Logger(Irc3Logger):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def process(self, **kwargs):
+        super().process(**kwargs)
+
+    @irc3.event((r'''(@(?P<tags>\S+) )?(?P<event>[A-Z]+) (?P<target>#\S+)'''
+                 r'''(\s:(?P<data>.*)|$)'''), iotype='out')
+    def on_output(self, event, target=None, data=None, **kwargs):
+        super().on_output(event, target, data, **kwargs)
+
+    @irc3.event((r'''(@(?P<tags>\S+) )?:(?P<mask>\S+) (?P<event>[A-Z]+)'''
+                 r''' (?P<target>#\S+)(\s:(?P<data>.*)|$)'''))
+    def on_input(self, mask, event, target=None, data=None, **kwargs):
+        super().on_input(mask, event, target, data, **kwargs)

--- a/ircb/lib/constants/signals.py
+++ b/ircb/lib/constants/signals.py
@@ -39,3 +39,15 @@ STORE_CLIENT_CREATE = 'store-client-create'
 STORE_CLIENT_CREATED = 'store-client-created'
 STORE_CLIENT_DELETE = 'store-client-delete'
 STORE_CLIENT_DELETED = 'store-client-deleted'
+
+# MessageLog store
+STORE_MESSAGELOG_GET = 'store-messagelog-get'
+STORE_MESSAGELOG_GOT = 'store-messagelog-got'
+STORE_MESSAGELOG_CREATE = 'store-messagelog-create'
+STORE_MESSAGELOG_CREATED = 'store-messagelog-created'
+
+# ActivityLog store
+STORE_ACTIVITYLOG_GET = 'store-activitylog-get'
+STORE_ACTIVITYLOG_GOT = 'store-activitylog-got'
+STORE_ACTIVITYLOG_CREATE = 'store-activitylog-create'
+STORE_ACTIVITYLOG_CREATED = 'store-activitylog-created'

--- a/ircb/models/__init__.py
+++ b/ircb/models/__init__.py
@@ -3,6 +3,7 @@ from .network import Network
 from .user import User
 from .channel import Channel
 from .client import Client
+from .logs import MessageLog, ActivityLog
 from .lib import create_tables, get_session, Base
 
 __all__ = [
@@ -10,6 +11,8 @@ __all__ = [
     'Client',
     'Network',
     'User',
+    'MessageLog',
+    'ActivityLog',
     'get_session',
     'create_tables',
     'Base'

--- a/ircb/models/logs.py
+++ b/ircb/models/logs.py
@@ -23,6 +23,13 @@ class BaseLog(object):
     last_updated = sa.Column(sa.DateTime,
                              default=datetime.datetime.utcnow)
 
+    def to_dict(self, serializable=False):
+        d = super().to_dict()
+        if serializable:
+            d['timestamp'] = self.timestamp.timestamp()
+            d['created'] = self.created.timestamp()
+            d['last_updated'] = self.last_updated.timestamp()
+
 
 class MessageLog(Base, BaseLog):
     """

--- a/ircb/models/logs.py
+++ b/ircb/models/logs.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import datetime
+import sqlalchemy as sa
+
+from ircb.models.lib import Base
+
+
+class BaseLog(object):
+    id = sa.Column(sa.Integer, primary_key=True)
+
+    hostname = sa.Column(sa.String(100), nullable=False)
+    roomname = sa.Column(sa.String(255), nullable=False)
+
+    message = sa.Column(sa.String(2048), default='')
+    event = sa.Column(sa.String(20), nullable=False)
+    timestamp = sa.Column(sa.TIMESTAMP(timezone=True))
+    mask = sa.Column(sa.String(100), default='')
+
+    user_id = sa.Column(sa.Integer)
+
+    # timestamps
+    created = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
+    last_updated = sa.Column(sa.DateTime,
+                             default=datetime.datetime.utcnow)
+
+
+class MessageLog(Base, BaseLog):
+    """
+    Network/Channel/PM messages
+    """
+    __tablename__ = 'message_logs'
+
+    from_nickname = sa.Column(sa.String(20))
+    from_user_id = sa.Column(sa.Integer, nullable=True, default=None)
+
+
+class ActivityLog(Base, BaseLog):
+    """
+    Channel activity(join, part, quit) logs
+    """
+    __tablename__ = 'activity_logs'

--- a/ircb/storeclient/__init__.py
+++ b/ircb/storeclient/__init__.py
@@ -6,6 +6,7 @@ from .client import ClientStore
 from .channel import ChannelStore
 from .user import UserStore
 from .base import init
+from .logs import MessageLogStore, ActivityLogStore
 
 
 def initialize():
@@ -18,5 +19,7 @@ __all__ = [
     'NetworkStore',
     'ChannelStore',
     'UserStore',
+    'MessageLogStore',
+    'ActivityLogStore',
     'initialize'
 ]

--- a/ircb/storeclient/logs.py
+++ b/ircb/storeclient/logs.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from ircb.models import MessageLog, ActivityLog
+from ircb.storeclient.base import BaseStore
+from ircb.lib.constants.signals import (STORE_MESSAGELOG_CREATE,
+                                        STORE_MESSAGELOG_CREATED,
+                                        STORE_MESSAGELOG_GET,
+                                        STORE_MESSAGELOG_GOT,
+                                        STORE_ACTIVITYLOG_CREATE,
+                                        STORE_ACTIVITYLOG_CREATED,
+                                        STORE_ACTIVITYLOG_GET,
+                                        STORE_ACTIVITYLOG_GOT)
+
+
+class MessageLogStore(BaseStore):
+    CREATE_SIGNAL = STORE_MESSAGELOG_CREATE
+    CREATED_SIGNAL = STORE_MESSAGELOG_CREATED
+    GET_SIGNAL = STORE_MESSAGELOG_GET
+    GOT_SIGNAL = STORE_MESSAGELOG_GOT
+
+    model = MessageLog
+
+
+class ActivityLogStore(BaseStore):
+    CREATE_SIGNAL = STORE_ACTIVITYLOG_CREATE
+    CREATED_SIGNAL = STORE_ACTIVITYLOG_CREATED
+    GET_SIGNAL = STORE_ACTIVITYLOG_GET
+    GOT_SIGNAL = STORE_ACTIVITYLOG_GOT
+
+    model = ActivityLog

--- a/ircb/stores/__init__.py
+++ b/ircb/stores/__init__.py
@@ -7,6 +7,7 @@ from .network import NetworkStore
 from .client import ClientStore
 from .channel import ChannelStore
 from .user import UserStore
+from .logs import MessageLogStore, ActivityLogStore
 from .base import init
 
 
@@ -17,10 +18,14 @@ def initialize():
     ClientStore.initialize()
     ChannelStore.initialize()
     UserStore.initialize()
+    MessageLogStore.initialize()
+    ActivityLogStore.initialize()
 
 __all__ = [
     'ClientStore',
     'NetworkStore',
     'ChannelStore',
-    'UserStore'
+    'UserStore',
+    'MessageLogStore',
+    'ActivityLogStore'
 ]

--- a/ircb/stores/logs.py
+++ b/ircb/stores/logs.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import datetime
+from ircb.lib.constants.signals import (STORE_MESSAGELOG_CREATE,
+                                        STORE_MESSAGELOG_CREATED,
+                                        STORE_MESSAGELOG_GET,
+                                        STORE_MESSAGELOG_GOT,
+                                        STORE_ACTIVITYLOG_CREATE,
+                                        STORE_ACTIVITYLOG_CREATED,
+                                        STORE_ACTIVITYLOG_GET,
+                                        STORE_ACTIVITYLOG_GOT)
+from ircb.models import get_session, MessageLog, ActivityLog
+from ircb.stores.base import BaseStore
+
+session = get_session()
+
+
+class MessageLogStore(BaseStore):
+    GET_SIGNAL = STORE_MESSAGELOG_GET
+    GOT_SIGNAL = STORE_MESSAGELOG_GOT
+    CREATE_SIGNAL = STORE_MESSAGELOG_CREATE
+    CREATED_SIGNAL = STORE_MESSAGELOG_CREATED
+
+    @classmethod
+    def get(cls, query):
+        pass
+
+    @classmethod
+    def create(cls, hostname, roomname, message, event, timestamp,
+               mask, user_id, from_nickname, from_user_id=None):
+        log = MessageLog(
+            hostname=hostname, roomname=roomname, message=message,
+            event=event, timestamp=datetime.datetime.fromtimestamp(timestamp),
+            mask=mask, user_id=user_id, from_nickname=from_nickname,
+            from_user_id=from_user_id)
+        session.add(log)
+        session.commit()
+        return log
+
+
+class ActivityLogStore(BaseStore):
+    CREATE_SIGNAL = STORE_ACTIVITYLOG_CREATE
+    CREATED_SIGNAL = STORE_ACTIVITYLOG_CREATED
+    GET_SIGNAL = STORE_ACTIVITYLOG_GET
+    GOT_SIGNAL = STORE_ACTIVITYLOG_GOT
+
+    @classmethod
+    def get(cls):
+        pass
+
+    @classmethod
+    def create(cls, hostname, roomname, message, event, timestamp,
+               mask, user_id):
+        log = ActivityLog(
+            hostname=hostname, roomname=roomname, message=message,
+            event=event, timestamp=datetime.datetime.fromtimestamp(timestamp),
+            mask=mask, user_id=user_id)
+        session.add(log)
+        session.commit()
+        return log


### PR DESCRIPTION
This will allow us to store IRC logs:
- channel
- network
- PM
- activity (join, part, kick, quit, etc)

in database, if the plugin is enabled.
## TODOs
- [x] Design table schema
- [x] Extend `irc3`'s `logger` plugin to save message and activity logs
- [x] Integrate with stores
- [x] Publish store messages
